### PR TITLE
Pin Go 1.26.2 toolchain to fix broken Docker builds on main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Build the manager binary
 FROM --platform=$BUILDPLATFORM golang:1.26.2-bookworm AS builder
 
-# Prevent Go from downloading a different toolchain at build time.
-# The Docker image IS the toolchain — if go.mod requires something newer,
-# we want a loud failure, not a silent download.
+# Set explicitly — the golang image defaults to this today, but we pin it
+# so the policy is visible and survives upstream default changes.
+# The Docker image IS the toolchain: fail loudly, never download silently.
 ENV GOTOOLCHAIN=local
 
 ARG TARGETOS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24.1 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-bookworm AS builder
+
+# Prevent Go from downloading a different toolchain at build time.
+# The Docker image IS the toolchain — if go.mod requires something newer,
+# we want a loud failure, not a silent download.
+ENV GOTOOLCHAIN=local
+
 ARG TARGETOS
 ARG TARGETARCH
 ARG BUILDPLATFORM

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/ironcore-dev/cloud-hypervisor-provider
 
 go 1.25.0
 
+toolchain go1.26.2
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/digitalocean/go-qemu v0.0.0-20250212194115-ee9b0668d242


### PR DESCRIPTION
The go.mod required Go 1.25.0 but the Dockerfile still used 1.24.1, causing go mod download to fail with GOTOOLCHAIN=local.

Set GOTOOLCHAIN=local explicitly even though the golang Docker images already default to it — this documents the intent in the Dockerfile and ensures the policy survives if the upstream image ever changes the default.
